### PR TITLE
Fix for unicode calendar name comparison

### DIFF
--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -234,7 +234,7 @@ class NetCDFTimeConverter(mdates.DateConverter):
             if len(calendars) == 1:
                 calendar = calendars.pop()
             else:
-                raise ValueError('Calendar units are not all equal: ' + calendars)
+                raise ValueError('Calendar units are not all equal: ' + str(calendars))
         else:
             # Deal with a single `sample_point` value.
             if not hasattr(sample_point, 'calendar'):

--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -230,11 +230,11 @@ class NetCDFTimeConverter(mdates.DateConverter):
             # Deal with nD `sample_point` arrays.
             if isinstance(sample_point, np.ndarray):
                 sample_point = sample_point.reshape(-1)
-            calendars = np.array([point.calendar for point in sample_point])
-            if np.all(calendars[0] == calendars):
-                calendar = calendars[0]
+            calendars = set([point.calendar for point in sample_point])
+            if len(calendars) == 1:
+                calendar = calendars.pop()
             else:
-                raise ValueError('Calendar units are not all equal.')
+                raise ValueError('Calendar units are not all equal: ' + calendars)
         else:
             # Deal with a single `sample_point` value.
             if not hasattr(sample_point, 'calendar'):


### PR DESCRIPTION
This fix makes sure that checking whether all calendar names are the same also works with unicode strings.

```python
import numpy as np

strings = np.array(['360_day', '360_day', '360_day'])
u_strings = np.array([u'360_day', u'360_day', u'360_day'])
mixed = np.array(['360_day', u'360_day', u'360_day'])

strings[0] == strings
# array([ True,  True,  True], dtype=bool)

u_strings[0] == u_strings
# False

strings[0].__eq__(strings)
# NotImplemented
# -> try __eq__ of other

strings.__eq__(strings[0])  #  works
# array([ True,  True,  True], dtype=bool)

u_strings[0].__eq__(u_strings)  # unicode is picky
# False

# changing order works
u_strings.__eq__(u_strings[0])
# array([ True,  True,  True], dtype=bool)

# Use `set` to avoid comparisons
set(['360_day', u'360_day'])
#{'360_day'}
```
